### PR TITLE
XML Datastream Settings page: Adjust arguments

### DIFF
--- a/islandora_sync.module
+++ b/islandora_sync.module
@@ -43,7 +43,7 @@ function islandora_sync_menu() {
   $items['admin/islandora/tools/sync/xml-datastreams/%/edit'] = array(
     'title' => 'Edit XML Datastream Settings',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('islandora_sync_xml_ds_add', 4),
+    'page arguments' => array('islandora_sync_xml_ds_add', 5),
     'access arguments' => array('islandora sync settings'),
     'type' => MENU_CALLBACK,
     'file' => 'includes/xml_ds_settings.form.inc',
@@ -51,7 +51,7 @@ function islandora_sync_menu() {
   $items['admin/islandora/tools/sync/xml-datastreams/%/delete'] = array(
     'title' => 'Delete XML Datastream Settings',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('islandora_sync_xml_ds_delete', 4),
+    'page arguments' => array('islandora_sync_xml_ds_delete', 5),
     'access arguments' => array('islandora sync settings'),
     'type' => MENU_CALLBACK,
     'file' => 'includes/xml_ds_settings.form.inc',


### PR DESCRIPTION
As you know, the path to the "XML Datastream Settings" page changed from: <ul><li>"/admin/islandora/sync/xml-datastreams" (7.x-1.3) to</li> <li>"/admin/islandora<strong>/tools/</strong>sync/xml-datastreams" (7.x-1.4, HEAD).</li></ul>

In the Islandora Sync module, hook_menu() grabs arguments from the URL -- such as the datastream ID. However, the indexes of these arguments were not adjusted after the path changed. As a result, instead of grabbing, say, "MODS" from the URL, it grabs the preceding argument "xml-datastreams" instead. The subsequent functions are fed a bad datastream ID, making it impossible to edit or delete any existing XML datastream settings. This patch adjusts the arguments to fix this problem.

<em>NOTE:</em> Clear Drupal's performance cache after applying this patch.
