### PR TITLE
Islandora Sync: Fixes / Enhancements

### DIFF
--- a/includes/import_to_drupal.inc
+++ b/includes/import_to_drupal.inc
@@ -76,11 +76,6 @@ function islandora_sync_import_from_pid($pid, $type, $nid = FALSE, $ds_id = NULL
  *   The Fedora object datastream ID.
  */
 function islandora_sync_build_node_fields(&$node, $object, $ds_id) {
-  // Check to see if a folder already exists for this node, if not create it.
-  $node_path = "public://islandora_sync/$node->nid";
-  if (!file_prepare_directory($node_path)) {
-    drupal_mkdir($node_path);
-  }
   $fields_to_populate_query = db_select('islandora_sync_fields', 'isf');
   $fields_to_populate_query->leftJoin('field_config', 'fc', 'fc.field_name = isf.field');
   $fields_to_populate_query->fields('isf')
@@ -235,8 +230,34 @@ function islandora_sync_save_field($field_info, &$entity, $value) {
       module_load_include('inc', 'islandora', 'mime_detect');
       $mime_detect = new MimeDetect();
       $extension = $mime_detect->getExtension($value['mimetype']);
-      $file_name = $field_info->dsid . '-' . $entity->type . '-' . $id . '.' . $extension;
-      $file_uri = "public://islandora_sync/$id/$file_name";
+      // retrieve the settings for this field.
+      $field_settings = field_info_instance('node', $field_info->field, $entity->type);
+
+      // Determine if the field configuration has already
+      // specified a subdirectory where files should be saved.
+      if ((isset($field_settings['settings']['file_directory'])) &&
+          ( trim($field_settings['settings']['file_directory'])  != "")) {
+        $file_name_component = NULL;
+        // Use the subdirectory path already specified in the field configuration.
+        $subdirectory = $field_settings['settings']['file_directory'];
+        $node_path = "public://$subdirectory";
+        if (strtolower($field_info->dsid) != $extension) {
+          $file_name_component = '-' . str_replace($extension, '', strtolower($field_info->dsid));
+        }
+        $file_name = $entity->type . '-' . $id . $file_name_component . '.' . $extension;
+      }
+      // Otherwise, by default, a folder should be created
+      // for each node ID and the derivatives saved there.
+      else {
+        $node_path = "public://islandora_sync/$id";
+        $file_name = $field_info->dsid . '-' . $entity->type . '-' . $id . '.' . $extension;
+      }
+
+      $file_uri = "$node_path/$file_name";
+      // Check to see if a folder already exists for this node. If not, create it.
+      if (!file_prepare_directory($node_path)) {
+        drupal_mkdir($node_path);
+      }
       if (module_exists('image')) {
         image_path_flush($file_uri);
       }

--- a/includes/import_to_drupal.inc
+++ b/includes/import_to_drupal.inc
@@ -238,14 +238,10 @@ function islandora_sync_save_field($field_info, &$entity, $value) {
       // specified a subdirectory where files should be saved.
       if ((isset($field_settings['settings']['file_directory'])) &&
           (trim($field_settings['settings']['file_directory']) != "")) {
-        $file_name_component = NULL;
         // Use subdirectory path already specified in the field configuration.
         $subdirectory = $field_settings['settings']['file_directory'];
         $node_path = "public://$subdirectory";
-        if (strtolower($field_info->dsid) != $extension) {
-          $file_name_component = '-' . str_replace($extension, '', strtolower($field_info->dsid));
-        }
-        $file_name = $entity->type . '-' . $id . $file_name_component . '.' . $extension;
+        $file_name = $entity->type . '-' . $id . '.' . $extension;
       }
       // Otherwise, by default, a folder should be created
       // for each node ID and the derivatives saved there.

--- a/includes/import_to_drupal.inc
+++ b/includes/import_to_drupal.inc
@@ -151,7 +151,7 @@ function islandora_sync_get_field_values($field, $object, $bundle, $parents = ar
         $read_path = '//';
       }
 
-	  $field_path = $field->read_path;
+      $field_path = $field->read_path;
       if ($field->read_context == 'parent') {
         $parent_path = islandora_sync_get_parent_path($field, $bundle, $parents);
         $read_path .= $parent_path;
@@ -275,6 +275,14 @@ function islandora_sync_save_field($field_info, &$entity, $value) {
         }
       }
       $prepared_field[]['tid'] = $term_id;
+      break;
+
+    case 'entityreference':
+      // Grab the last instance of a number found
+      // between parentheses. That's the term ID.
+      preg_match('/\((\d+)\)$/',  $value, $matches);
+      $value = ((count($matches) >= 2) ? $matches[(count($matches) - 1)] : $matches[0]);
+      $prepared_field[]['target_id'] = $value;
       break;
 
     case 'text_long':

--- a/includes/import_to_drupal.inc
+++ b/includes/import_to_drupal.inc
@@ -89,7 +89,8 @@ function islandora_sync_build_node_fields(&$node, $object, $ds_id) {
   $fields_to_populate = $fields_to_populate_query->execute()->fetchAll();
 
   foreach ($fields_to_populate as $field) {
-    $field->pid = $object->id; // Add the Fedora ID to the object.
+    // Add the Fedora ID to the object.
+    $field->pid = $object->id;
     $return = module_invoke_all('islandora_sync_node_field_build', $node, $object, $field, $ds_id);
 
     if (!$return) {
@@ -230,15 +231,15 @@ function islandora_sync_save_field($field_info, &$entity, $value) {
       module_load_include('inc', 'islandora', 'mime_detect');
       $mime_detect = new MimeDetect();
       $extension = $mime_detect->getExtension($value['mimetype']);
-      // retrieve the settings for this field.
+      // Retrieve the settings for this field.
       $field_settings = field_info_instance('node', $field_info->field, $entity->type);
 
       // Determine if the field configuration has already
       // specified a subdirectory where files should be saved.
       if ((isset($field_settings['settings']['file_directory'])) &&
-          ( trim($field_settings['settings']['file_directory'])  != "")) {
+          (trim($field_settings['settings']['file_directory']) != "")) {
         $file_name_component = NULL;
-        // Use the subdirectory path already specified in the field configuration.
+        // Use subdirectory path already specified in the field configuration.
         $subdirectory = $field_settings['settings']['file_directory'];
         $node_path = "public://$subdirectory";
         if (strtolower($field_info->dsid) != $extension) {
@@ -254,7 +255,7 @@ function islandora_sync_save_field($field_info, &$entity, $value) {
       }
 
       $file_uri = "$node_path/$file_name";
-      // Check to see if a folder already exists for this node. If not, create it.
+      // Check if a folder already exists for this node. If not, create it.
       if (!file_prepare_directory($node_path)) {
         drupal_mkdir($node_path);
       }
@@ -301,7 +302,7 @@ function islandora_sync_save_field($field_info, &$entity, $value) {
     case 'entityreference':
       // Grab the last instance of a number found
       // between parentheses. That's the term ID.
-      preg_match('/\((\d+)\)$/',  $value, $matches);
+      preg_match('/\((\d+)\)$/', $value, $matches);
       if (count($matches) > 0) {
         $value = ((count($matches) >= 2) ? $matches[(count($matches) - 1)] : $matches[0]);
         $prepared_field[]['target_id'] = $value;
@@ -310,8 +311,10 @@ function islandora_sync_save_field($field_info, &$entity, $value) {
 
     case 'text_long':
     case 'text_with_summary':
-      $prepared_field[] = array('value'  => $value,
-                                'format' => filter_default_format());
+      $prepared_field[] = array(
+        'value'  => $value,
+        'format' => filter_default_format()
+      );
       break;
 
     default:

--- a/includes/import_to_drupal.inc
+++ b/includes/import_to_drupal.inc
@@ -35,9 +35,8 @@ function islandora_sync_import_from_pid($pid, $type, $nid = FALSE, $ds_id = NULL
     $node->log = 'Updated by islandora_sync';
   }
 
-  if (!isset($node->title)) {
-    $node->title = $object->label;
-  }
+  // Ensure the node title and object title always match.
+  $node->title = $object->label;
 
   $author = user_load_by_name($object->owner);
   if ($author) {
@@ -95,6 +94,7 @@ function islandora_sync_build_node_fields(&$node, $object, $ds_id) {
   $fields_to_populate = $fields_to_populate_query->execute()->fetchAll();
 
   foreach ($fields_to_populate as $field) {
+    $field->pid = $object->id; // Add the Fedora ID to the object.
     $return = module_invoke_all('islandora_sync_node_field_build', $node, $object, $field, $ds_id);
 
     if (!$return) {
@@ -151,9 +151,7 @@ function islandora_sync_get_field_values($field, $object, $bundle, $parents = ar
         $read_path = '//';
       }
 
-      $field_path = db_query("SELECT read_path FROM {islandora_sync_fields} WHERE field = :field AND bundle = :bundle",
-        array(':field' => $field->field, ':bundle' => $field->bundle)
-      )->fetchField();
+	  $field_path = $field->read_path;
       if ($field->read_context == 'parent') {
         $parent_path = islandora_sync_get_parent_path($field, $bundle, $parents);
         $read_path .= $parent_path;
@@ -248,15 +246,19 @@ function islandora_sync_save_field($field_info, &$entity, $value) {
       break;
 
     case 'taxonomy_term_reference':
-      $term_field_info = db_query("SELECT * FROM {field_config_instance} WHERE field_name = :field_name AND bundle = :bundle",
-        array(':field_name' => $field_info->field, ':bundle' => $field_info->bundle)
+      // Find the vocabulary to which this taxonomy term belongs.
+      // https://groups.google.com/d/msg/islandora/MytIAZrMdwg/3FpwJZ06eeMJ
+      $term_field_info = db_query("SELECT data FROM {field_config} WHERE field_name = :field_name",
+        array(':field_name' => $field_info->field)
       )->fetchObject();
       $term_data = unserialize($term_field_info->data);
-      $vid = db_query("SELECT vid FROM {taxonomy_vocabulary} WHERE name = :name",
-        array(':name' => $term_data['label'])
-      )->fetchField();
-
-      $terms = taxonomy_get_term_by_name($value);
+      $vocab_machine_name = $term_data['settings']['allowed_values'][0]['vocabulary'];
+      $vocab_object = taxonomy_vocabulary_machine_name_load($vocab_machine_name);
+      $vid = $vocab_object->vid;
+      // Remove any quotation marks at the beginning and/or end of the term.
+      $value = trim($value, '"');
+      // When searching for the term, only look in the appropriate vocabulary.
+      $terms = taxonomy_get_term_by_name($value, $vocab_machine_name);
       if (!empty($terms)) {
         $term_id = key($terms);
       }
@@ -273,6 +275,12 @@ function islandora_sync_save_field($field_info, &$entity, $value) {
         }
       }
       $prepared_field[]['tid'] = $term_id;
+      break;
+
+    case 'text_long':
+    case 'text_with_summary':
+      $prepared_field[] = array('value'  => $value,
+                                'format' => filter_default_format());
       break;
 
     default:

--- a/includes/import_to_drupal.inc
+++ b/includes/import_to_drupal.inc
@@ -313,7 +313,7 @@ function islandora_sync_save_field($field_info, &$entity, $value) {
     case 'text_with_summary':
       $prepared_field[] = array(
         'value'  => $value,
-        'format' => filter_default_format()
+        'format' => filter_default_format(),
       );
       break;
 

--- a/includes/import_to_drupal.inc
+++ b/includes/import_to_drupal.inc
@@ -302,8 +302,10 @@ function islandora_sync_save_field($field_info, &$entity, $value) {
       // Grab the last instance of a number found
       // between parentheses. That's the term ID.
       preg_match('/\((\d+)\)$/',  $value, $matches);
-      $value = ((count($matches) >= 2) ? $matches[(count($matches) - 1)] : $matches[0]);
-      $prepared_field[]['target_id'] = $value;
+      if (count($matches) > 0) {
+        $value = ((count($matches) >= 2) ? $matches[(count($matches) - 1)] : $matches[0]);
+        $prepared_field[]['target_id'] = $value;
+      }
       break;
 
     case 'text_long':
@@ -313,7 +315,9 @@ function islandora_sync_save_field($field_info, &$entity, $value) {
       break;
 
     default:
-      $prepared_field[]['value'] = $value;
+      if (trim($value) != '') {
+        $prepared_field[]['value'] = $value;
+      }
   }
 }
 

--- a/islandora_sync_field_collection/islandora_sync_field_collection.module
+++ b/islandora_sync_field_collection/islandora_sync_field_collection.module
@@ -50,6 +50,13 @@ function islandora_sync_field_collection_islandora_sync_node_field_build($node, 
 
         foreach ($values as $k => $v) {
           if (isset($v[$i]) && $v[$i]) {
+            // At this level, all fields in this collection will generically have a
+            // 'type' value of 'field_collection'. Determine the actual 'type' of each
+            // individual field and update the object with that value. Otherwise,
+            // islandora_sync_save_field() will make incorrect decisions based on type.
+            $field_data = field_info_field($child_fields[$k]->field);
+            $field_type = (isset($field_data['type']) ? $field_data['type'] : $child_fields[$k]->type);
+            $child_fields[$k]->type = $field_type;
             islandora_sync_save_field($child_fields[$k], $field_collection_item, $v[$i]);
           }
         }


### PR DESCRIPTION
We use a customized version of Islandora Sync on our production site, <a href="http://www.worthingtonmemory.org">Worthington Memory</a>. This pull request includes most of the modifications we made along the way. The remaining changes are too specific to our particular setup and/or too weird to be generalized for other environments. 

Changes in this pull request include:

<ul><li><strong>Data mapping fixes and enhancements</strong>, so Islandora Sync has a better time mapping to <a href="https://www.drupal.org/project/field_collection">field collections</a>, taxonomy term references, <a href="https://www.drupal.org/project/entityreference">entity reference fields</a>, and long text.</li> <li><strong>Image field / file field subdirectories:</strong> Drupal file and image fields include a configuration screen where you can specify a subdirectory for saving attached files. Whenever that's filled out, Islandora Sync now uses it. If not, it follows the module's default behavior, which is to create a directory named after the node ID (inside an "islandora_sync" folder) and save the files there.</li></ul>


Note that this pull request only impacts the Fedora-to-Drupal import process. Islandora Sync can also do the reverse (import Drupal content into Fedora) -- but no changes have been made to that.
